### PR TITLE
Bug if comments enabled

### DIFF
--- a/templates/partials/comment.html
+++ b/templates/partials/comment.html
@@ -1,5 +1,6 @@
+{% from 'partials/_defaults.html' import obj with context %}
 {% if DISQUS_SITENAME or MUUT_SITENAME %}
-    {% if obj is defined and obj.comments|title != 'False' %}
+    {% if obj.comments is defined and obj.comments|title != 'False' %}
         <div class="eevee-comment" id="article-comments">
             <section itemscope itemtype='http://schema.org/UserComments'>
                 <h2>Join the discussion</h2>

--- a/templates/partials/share.html
+++ b/templates/partials/share.html
@@ -33,7 +33,7 @@
                     </a>
                 </li>
                 {% if MUUT_SITENAME or DISQUS_SITENAME %}
-                    {% if obj is defined and obj.comments|title != 'False' %}
+                    {% if obj.comments is defined and obj.comments|title != 'False' %}
                         <li class="social-share__link social-share__link--comment">
                             <a href="#article-comments" title="Discuss '{{ share_title|striptags }}'">
                              <i class="material-icons" aria-hidden="true">&#xE0B9;</i>


### PR DESCRIPTION
Hi, 

if `comments` is not defined in blog post then blog creation chrashes. Jinja2 wants to pass `None` to the title filter which crashes blog generation.

best brodul